### PR TITLE
use correct framework

### DIFF
--- a/HowWellYouKnow.API/HowWellYouKnow.API/HowWellYouKnow.API.csproj
+++ b/HowWellYouKnow.API/HowWellYouKnow.API/HowWellYouKnow.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>

--- a/HowWellYouKnow.API/HowWellYouKnow.Domain/HowWellYouKnow.Domain.csproj
+++ b/HowWellYouKnow.API/HowWellYouKnow.Domain/HowWellYouKnow.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HowWellYouKnow.API/HowWellYouKnow.Infrastructure/HowWellYouKnow.Infrastructure.csproj
+++ b/HowWellYouKnow.API/HowWellYouKnow.Infrastructure/HowWellYouKnow.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HowWellYouKnow.API/HowWellYouKnow.Tests/HowWellYouKnow.Tests.csproj
+++ b/HowWellYouKnow.API/HowWellYouKnow.Tests/HowWellYouKnow.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks